### PR TITLE
Add label refinement functions. Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This application applies ITK image processing algorithms.<br />
 ## Usage
 
 Run application from Build/Debug/TeamSky.exe [args]<br />
-Currently options must be written in order.<br />
+Options/arguments must be written in order.<br />
 
 Possible args are:<br />
 
@@ -15,9 +15,9 @@ Possible args are:<br />
 | --- | --- |
 | \-h, \-\-help | Display help menu |
 | \-r | Registration |
-| \-s image threshold level | Watershed Segmentation on image with specified threshold and level |
+| \-s image threshold level [labelVal] | Watershed Segmentation on image with specified threshold and level. Remove labels who have a membership count less than labelVal, defaults to zero. |
 | \-3d image_dir num | Create 3D image from multiple 2D images. image_dir is a directory containing images named like 000000.dcm. num is the number of images you want to use in that directory from 000000.dcm through 00000N.dcm |
-| \-f filter_name [args] | Apply generic filter to image. Optional args may be required by different filter types. Filters currently supported: median |
+| \-f filter_name [args] | Apply generic filter to image. Optional args may be required by different filter types. Filters currently supported: median, dgaussian, bilateral. |
 
 ## Examples
 
@@ -29,12 +29,20 @@ Display help menu.<br />
 Create a 3D volume from 25 images that are in the directory ../../Images/test_set_1 named as 000000.dcm through 000024.dcm<br />
 <br />
 
+`TeamSky.exe -f median`<br />
+Since no filter arguments are provided, usage information for median filter will be displayed.<br />
+<br />
+
 `TeamSky.exe -f median image.dcm 2`<br />
 Apply median filter with a radius of 2 to the image file, image.dcm.<br />
 <br />
 
 `TeamSky.exe -s image.dcm 0.0025 0.25`<br />
-Apply watershed segmentation to image.dcm with threshold set to 0.0025 and level set to 0.25. It is recommended to apply some smoothing filter to the image before applying watershed segmentation<br />
+Apply watershed segmentation to image.dcm with threshold set to 0.0025 and level set to 0.25. It is recommended to apply some smoothing filter to the image before applying watershed segmentation.<br />
+<br />
+
+`TeamSky.exe -s image.dcm 0.0025 0.25 1200`<br />
+Apply watershed segmentation to image.dcm with threshold set to 0.0025 and level set to 0.25. It is recommended to apply some smoothing filter to the image before applying watershed segmentation. The last argument removed labels/segments that have a membership count less than or equal to 1200. Note: this value fluctuates with the size of the image. <br />
 <br />
 
 More options and examples to be added later.

--- a/Source/TeamSky.cxx
+++ b/Source/TeamSky.cxx
@@ -15,12 +15,14 @@ int main(int argc, char* argv[])
 		// display help	
 		//std::cout << "Team Sky ITK" << std::endl;
 		printf("%-30s\n", "Team Sky ITK");
-		printf("%-30s %-30s\n", "-h", "Display help menu");
+		printf("%-30s %-30s\n", "-h, --help", "Display help menu");
 		printf("%-30s %-30s\n", "-r", "Registration");
 		printf("%-30s %-30s\n", "-s image thresh level [labelVal]", "Apply watershed segmentation with threshold and level.");
 		printf("%-30s %-30s\n", " ", "Remove labels that have a count less than labelVal (defaults to 0). ");
 		printf("%-30s %-30s\n", "-3D image_dir num", "Create 3D image from multiple 2D images");
-		printf("%-30s %-30s\n", "-f filter_name [args]", "Apply filter to image. Filters supported: median");
+		printf("%-30s %-30s\n", "-f filter_name [args]", "Apply filter to image. Filters supported: median, ");
+		printf("%-30s %-30s\n", " ", "dgaussian, bilateral");
+		printf("%-30s %-30s\n", " ", "Use \"-f filter_name\" without args to see usage. ");
 		std::cout << std::endl;
 		// add more options
 	}

--- a/Source/TeamSky.cxx
+++ b/Source/TeamSky.cxx
@@ -17,7 +17,8 @@ int main(int argc, char* argv[])
 		printf("%-30s\n", "Team Sky ITK");
 		printf("%-30s %-30s\n", "-h", "Display help menu");
 		printf("%-30s %-30s\n", "-r", "Registration");
-		printf("%-30s %-30s\n", "-s image threshold level", "Apply watershed segmentation with given threshold and level");
+		printf("%-30s %-30s\n", "-s image thresh level [labelVal]", "Apply watershed segmentation with threshold and level.");
+		printf("%-30s %-30s\n", " ", "Remove labels that have a count less than labelVal (defaults to 0). ");
 		printf("%-30s %-30s\n", "-3D image_dir num", "Create 3D image from multiple 2D images");
 		printf("%-30s %-30s\n", "-f filter_name [args]", "Apply filter to image. Filters supported: median");
 		std::cout << std::endl;
@@ -30,14 +31,19 @@ int main(int argc, char* argv[])
 	else if(strcmp(argv[1], "-s") == 0) {
 		std::cout << "Watershed Segmentation" << std::endl;
 		// Check watershed segmentation args
-		if(argc != 5) {
+		if(argc < 5) {
 			std::cerr << "ERROR: Invalid number of args" << std::endl;
 			std::cerr << "Usage: TeamSky.exe -s image threshold level" << std::endl;
 			return EXIT_FAILURE;
 		}
 		else {
 			WatershedSegmentation watershed = WatershedSegmentation(argv[2]);
-			std::string seg_filename = watershed.applyWatershedSegmentation(atof(argv[3]), atof(argv[4]));
+			std::string seg_filename;
+			if (argc < 6)
+				seg_filename = watershed.applyWatershedSegmentation(atof(argv[3]), atof(argv[4]));
+			else
+				seg_filename = watershed.applyWatershedSegmentation(atof(argv[3]), atof(argv[4]), atoi(argv[5]));
+
 			if(seg_filename.empty()) {
 				// file was not created or segmentation failed
 				std::cerr << "ERROR: Could not complete watershed segmentation" << std::endl;

--- a/Source/WatershedSegmentation.cxx
+++ b/Source/WatershedSegmentation.cxx
@@ -124,7 +124,6 @@ void WatershedSegmentation::updateLabels(
 	// Used to track total label stats (average count of all segments)
 	long avgCount = 0;
 	int labelMean = 0;
-	int maxLabelMean = -1000000;
 
 	// Iterate through the valid labels in the labelImage
 	int labelCount = 0;
@@ -142,7 +141,6 @@ void WatershedSegmentation::updateLabels(
 			}
 			// Remove labels for dark regions (extra regions on the edge)
 			labelMean = labelStatisticsImageFilter->GetMean(labelImageValue);
-			maxLabelMean = labelMean > maxLabelMean ? labelMean : maxLabelMean;
 			if (labelMean < 5) {
 				changeLabelImageFilter->SetChange(labelImageValue, background);
 			}

--- a/Source/WatershedSegmentation.h
+++ b/Source/WatershedSegmentation.h
@@ -1,6 +1,9 @@
 #include "itkImage.h"
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
+#include "itkWatershedImageFilter.h"
+#include "itkChangeLabelImageFilter.h"
+#include "itkLabelStatisticsImageFilter.h"
 
 #include <string>
 
@@ -10,16 +13,46 @@
 class WatershedSegmentation
 {
 private:
-	typedef float SegPixelType;
-	typedef itk::RGBPixel<unsigned char> RGBPixelType;
+	typedef float SegPixelType; // used for the input image (3D greyscale dicom image)
 	typedef itk::Image<SegPixelType, 3> SegImageType;
+
+	typedef itk::RGBPixel<unsigned char> RGBPixelType; // used to color output image
 	typedef itk::Image<RGBPixelType, 3> RGBImageType;
+
 	typedef itk::ImageFileReader<SegImageType> SegReaderType;
 	typedef itk::ImageFileWriter<RGBImageType> SegWriterType;
+	typedef itk::WatershedImageFilter<SegImageType> WatershedFilterType;
 
-	char* filename;
-	SegReaderType::Pointer seg_reader;
-	SegWriterType::Pointer seg_writer;
+	// Used to map labels to new labels
+	typedef itk::ChangeLabelImageFilter
+		<WatershedFilterType::OutputImageType, WatershedFilterType::OutputImageType> 
+		ChangeLabelImageFilterType;
+
+	// Used to get statistics on labelImages
+	typedef itk::LabelStatisticsImageFilter
+		<SegImageType, WatershedFilterType::OutputImageType> 
+		LabelStatisticsImageFilterType;
+
+	char* filename; // 3D greyscale dicom image file name
+	SegReaderType::Pointer seg_reader; // For reading dcm files
+	SegWriterType::Pointer seg_writer; // For writing dcm files
+
+	/*
+	Helper function that updates the labelImage produced by watershed segmentation.
+	Used to remove labels that do not meet a specified criteria. 
+
+	labelImage: label image produced by watershed segmentation.
+	originalImage: image produced by gradient image filter.
+	changeLabelImageFilter: ChangeLabelImageFilter that maps labels to background pixels.
+		changeLabelImageFilter is modified by this function. 
+	value: the number that determines the criteria that decides if a label should be removed. 
+	return: void.
+	*/
+	void updateLabels(
+		WatershedFilterType::OutputImageType::Pointer labelImage, 
+		SegImageType::Pointer originalImage,
+		ChangeLabelImageFilterType::Pointer changeLabelImageFilter,
+		int labelValue);
 
 public:
 	//constructor
@@ -27,12 +60,14 @@ public:
 
 	/*
 	Apply watershed segmentation to the specified image.
+
 	threshold: threshold value that segmentation will use
 	level: level value that segmentation will use
+	labelValue: used to remove labels/segments that have a count less than labelValue
 	return: Name of file where segmented image has been written to.
 	Returns empty string, "", if an error occured.
 	*/
-	std::string applyWatershedSegmentation(float threshold, float level);
+	std::string applyWatershedSegmentation(float threshold, float level, int labelValue = 0);
 };
 
 #endif


### PR DESCRIPTION
- Added functionality to watershed segmentation to remove labels whose membership count is less than a specified value. 
- Added code to watershed segmentation to remove labels whose mean value is less than 5. This removes labels in the image that correspond to very dark areas. This prevents applying labels to the outside regions of the image. 
- Updated README to reflect this changes.
- Updated main in TeamSky.cxx to add the optional argument for label membership count. 