### PR TITLE
Add code to read a Dicom series from a directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Possible args are:<br />
 | \-r | Registration |
 | \-s image threshold level [labelVal] | Watershed Segmentation on image with specified threshold and level. Remove labels who have a membership count less than labelVal, defaults to zero. |
 | \-3d image_dir num | Create 3D image from multiple 2D images. image_dir is a directory containing images named like 000000.dcm. num is the number of images you want to use in that directory from 000000.dcm through 00000N.dcm |
+| \-dicom image_dir | Create 3D image from multiple Dicom images in the same series. image_dir is a directory containing valid Dicom images. Output image is saved in the provided directory |
 | \-f filter_name [args] | Apply generic filter to image. Optional args may be required by different filter types. Filters currently supported: median, dgaussian, bilateral. |
 
 ## Examples
@@ -27,6 +28,10 @@ Display help menu.<br />
 
 `TeamSky.exe -3d ../../Images/test_set_1/ 25`<br />
 Create a 3D volume from 25 images that are in the directory ../../Images/test_set_1 named as 000000.dcm through 000024.dcm<br />
+<br />
+
+`TeamSky.exe -dicom ../../Images/0522c00001/set1`<br />
+Create a 3D volume from all Dicom images from the same series that are in the directory ../../Images/0522c00001/set1<br />
 <br />
 
 `TeamSky.exe -f median`<br />

--- a/Source/ReadDicom.cxx
+++ b/Source/ReadDicom.cxx
@@ -1,0 +1,91 @@
+#include "itkImage.h"
+#include "itkGDCMImageIO.h"
+#include "itkGDCMSeriesFileNames.h"
+#include "itkImageSeriesReader.h"
+#include "itkImageFileWriter.h"
+
+int readDicom(char* dir)
+{
+	std::string dirName = dir; // dicom directory
+
+	//using PixelType = signed short;
+	using PixelType = unsigned char;
+	constexpr unsigned int Dimension = 3;
+	using ImageType = itk::Image< PixelType, Dimension >;
+
+	using NamesGeneratorType = itk::GDCMSeriesFileNames;
+	NamesGeneratorType::Pointer nameGenerator = NamesGeneratorType::New();
+
+	nameGenerator->SetUseSeriesDetails(true);
+	nameGenerator->AddSeriesRestriction("0008|0021");
+	nameGenerator->SetGlobalWarningDisplay(false);
+	nameGenerator->SetDirectory(dirName);
+
+	try
+	{
+		using SeriesIdContainer = std::vector< std::string >;
+		const SeriesIdContainer & seriesUID = nameGenerator->GetSeriesUIDs();
+		auto seriesItr = seriesUID.begin();
+		auto seriesEnd = seriesUID.end();
+
+		// Check if there are any valid DICOM images in the directory
+		if (seriesItr == seriesEnd)
+		{
+			std::cout << "No DICOMs in: " << dirName << std::endl;
+			return EXIT_SUCCESS;
+		}
+
+		// Print series
+		while (seriesItr != seriesEnd)
+		{
+			std::cout << seriesItr->c_str() << std::endl;
+			++seriesItr;
+		}
+
+		seriesItr = seriesUID.begin();
+		while (seriesItr != seriesUID.end())
+		{
+			std::string seriesIdentifier;
+			seriesIdentifier = seriesItr->c_str();
+			seriesItr++;
+
+			using FileNamesContainer = std::vector< std::string >;
+			FileNamesContainer fileNames =
+				nameGenerator->GetFileNames(seriesIdentifier);
+
+			using ReaderType = itk::ImageSeriesReader< ImageType >;
+			ReaderType::Pointer reader = ReaderType::New();
+			using ImageIOType = itk::GDCMImageIO;
+			ImageIOType::Pointer dicomIO = ImageIOType::New();
+			reader->SetImageIO(dicomIO);
+			reader->SetFileNames(fileNames);
+			reader->Update();
+
+			using WriterType = itk::ImageFileWriter< ImageType >;
+			WriterType::Pointer writer = WriterType::New();
+			std::string outFileName;
+
+			outFileName = dirName + std::string("/") + "image_sequence.nrrd";
+
+			writer->SetFileName(outFileName);
+			writer->UseCompressionOn();
+			writer->SetInput(reader->GetOutput());
+			std::cout << "Writing: " << outFileName << std::endl;
+			try
+			{
+				writer->Update();
+			}
+			catch (itk::ExceptionObject &ex)
+			{
+				std::cout << ex << std::endl;
+				continue;
+			}
+		}
+	}
+	catch (itk::ExceptionObject &ex)
+	{
+		std::cout << ex << std::endl;
+		return EXIT_FAILURE;
+	}
+	return EXIT_SUCCESS;
+}

--- a/Source/TeamSky.cxx
+++ b/Source/TeamSky.cxx
@@ -20,11 +20,11 @@ int main(int argc, char* argv[])
 		printf("%-30s %-30s\n", "-r", "Registration");
 		printf("%-30s %-30s\n", "-s image thresh level [labelVal]", "Apply watershed segmentation with threshold and level.");
 		printf("%-30s %-30s\n", " ", "Remove labels that have a count less than labelVal (defaults to 0). ");
-		printf("%-30s %-30s\n", "-3D image_dir num", "Create 3D image from multiple 2D images");
-		printf("%-30s %-30s\n", "-dicom image_dir", "Create 3D image from multiple dicom images");
+		printf("%-30s %-30s\n", "-3D image_dir num", "Create 3D image from multiple 2D images.");
+		printf("%-30s %-30s\n", "-dicom image_dir", "Create 3D image from multiple dicom images using GDCM.");
 		printf("%-30s %-30s\n", "-f filter_name [args]", "Apply filter to image. Filters supported: median, ");
 		printf("%-30s %-30s\n", " ", "dgaussian, bilateral");
-		printf("%-30s %-30s\n", " ", "Use \"-f filter_name\" without args to see usage. ");
+		printf("%-30s %-30s\n", " ", "Use \"-f filter_name\" without args to see usage.");
 		std::cout << std::endl;
 		// add more options
 	}
@@ -92,7 +92,16 @@ int main(int argc, char* argv[])
 		}
 		else {
 			// use read dicom fcn
-			readDicom(argv[2]);
+			std::string dicom_filename = readDicom(argv[2]);
+			if (dicom_filename.empty()) {
+				// file was not created
+				std::cerr << "ERROR: Could not create 3D image" << std::endl;
+				return EXIT_FAILURE;
+			}
+			else {
+				// file was created
+				std::cout << "3D image created: " << dicom_filename << std::endl;
+			}
 		}
 	}
 	else if(strcmp(argv[1], "-f") == 0) {

--- a/Source/TeamSky.cxx
+++ b/Source/TeamSky.cxx
@@ -4,6 +4,7 @@
 #include "SmoothingFilters.cxx"
 #include "WatershedSegmentation.h"
 #include "WatershedSegmentation.cxx"
+#include "ReadDicom.cxx"
 
 #include <iostream>
 #include <stdio.h>
@@ -20,6 +21,7 @@ int main(int argc, char* argv[])
 		printf("%-30s %-30s\n", "-s image thresh level [labelVal]", "Apply watershed segmentation with threshold and level.");
 		printf("%-30s %-30s\n", " ", "Remove labels that have a count less than labelVal (defaults to 0). ");
 		printf("%-30s %-30s\n", "-3D image_dir num", "Create 3D image from multiple 2D images");
+		printf("%-30s %-30s\n", "-dicom image_dir", "Create 3D image from multiple dicom images");
 		printf("%-30s %-30s\n", "-f filter_name [args]", "Apply filter to image. Filters supported: median, ");
 		printf("%-30s %-30s\n", " ", "dgaussian, bilateral");
 		printf("%-30s %-30s\n", " ", "Use \"-f filter_name\" without args to see usage. ");
@@ -78,6 +80,19 @@ int main(int argc, char* argv[])
 				// file was created
 				std::cout << "3D image created: " << volume_filename << std::endl;
 			}
+		}
+	}
+	else if (strcmp(argv[1], "-dicom") == 0) {
+		std::cout << "Create 3D dicom image from multiple 2D dicom images" << std::endl;
+		// Check args: image directory and number of files
+		if (argc != 3) {
+			std::cerr << "ERROR: Invalid number of args" << std::endl;
+			std::cerr << "Usage: TeamSky.exe -dicom image_dir" << std::endl;
+			return EXIT_FAILURE;
+		}
+		else {
+			// use read dicom fcn
+			readDicom(argv[2]);
 		}
 	}
 	else if(strcmp(argv[1], "-f") == 0) {


### PR DESCRIPTION
- Added code to check for valid Dicom images in the provided directory.
- The program will look for valid Dicom images and read their metadata to determine if they are apart of the same series.
- A 3D .nrrd file will be saved to the image directory. To view in imageJ, the .nrrd file must be in the same directory and imported as an image sequence. 
- Added help menu and argument option support in TeamSky.cxx to handle new code. 